### PR TITLE
Improve formatting and remove duplicate sections of visitor.md and steward.md

### DIFF
--- a/02_roles-and-stakeholders/steward.md
+++ b/02_roles-and-stakeholders/steward.md
@@ -67,16 +67,6 @@ The Stewardship Program covers:
 - **Mentorship** - Regular sessions with program facilitators and community experts
 - **Certification** - Recognition of program completion and skills acquired
 
-## Learning Areas
-
-The Stewardship Program covers:
-
-- **Regenerative Agriculture** - Food production, soil health, and ecosystem management
-- **Community Living** - Communication, facilitation, and conflict transformation
-- **Appropriate Technology** - Energy, water, and building systems
-- **Governance & Economics** - Decision-making processes and regenerative economics
-- **Personal Development** - Self-awareness, leadership, and purpose work
-
 ---
 
 **Stewardships are TDF's invitation to learn by doing, grow by caring, and prototype the next era of human habitation — together.**

--- a/02_roles-and-stakeholders/visitor.md
+++ b/02_roles-and-stakeholders/visitor.md
@@ -15,6 +15,7 @@ Visitors are individuals who stay at TDF for a minimum of 1 month (except volunt
 ## Open-Day Programme
 
 TDF offers monthly open-day tours and lunch for short visits:
+
 - **Monthly Tours** - Guided exploration of the community and land
 - **Community Lunch** - Shared meal and conversation with community members
 - **Information Sessions** - Learn about TDF's mission and participation opportunities
@@ -33,8 +34,8 @@ As a Visitor, you are expected to:
 
 ## Contributions & Fees
 
-**Weekly Contribution**: 4 hours of meaningful work per week
-**Cooking Shifts**: Required if participating in the food program
+**Weekly Contribution**: 4 hours of meaningful work per week  
+**Cooking Shifts**: Required if participating in the food program  
 **Fee Structure**: Daily rate covers accommodation and utilities; separate fee for food program participation
 
 ## Opportunities
@@ -71,6 +72,7 @@ Anyone with an active booking (visitor or citizen) may invite a guest for a shor
 - **Support** - Be available to support the guest throughout their stay
 
 **Guest Expectations**
+
 - Follow all community guidelines and safety protocols
 - Respect the host's guidance and community norms
 - Participate appropriately in community activities
@@ -81,6 +83,7 @@ Anyone with an active booking (visitor or citizen) may invite a guest for a shor
 ## Food Program
 
 The food program is optional with a separate fee. Visitors can choose to:
+
 - **Join the Program** - Access to community meals and cooking shifts
 - **Opt Out** - Handle their own food needs independently
 


### PR DESCRIPTION
Was reading through the game guide and noticed that the Steward section had a duplicate Learning Areas section. Also seems like the is a line break issue in visitor.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed the "Learning Areas" section and its listed items.
  * Deleted a duplicated/trailing content block to prevent repetition.
  * Fixed end-of-file formatting (ensured trailing newline).

* **Style / Formatting**
  * Added blank lines and minor spacing tweaks across programme, guest-expectation and food sections.
  * Reflowed and aligned the fee-comparison table for clearer presentation.
  * Adjusted bullets and whitespace for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->